### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       interval: "weekly"
       day: "thursday"
 
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directories:
       - "webinars/Koyeb/.github/workflows"
@@ -32,6 +34,8 @@ updates:
       interval: "weekly"
       day: "thursday"
 
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directories:
       - "meetup/AI_Developer_Meetup/gatling"
@@ -45,3 +49,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
